### PR TITLE
Filter short RX glitches on ESP32

### DIFF
--- a/components/openthermgw/OpenTherm.cpp
+++ b/components/openthermgw/OpenTherm.cpp
@@ -140,6 +140,10 @@ void IRAM_ATTR OpenTherm::handleInterrupt()
 {
 	unsigned long newTs = micros();
 		
+	// Filter interrupts glitchs
+	if ((newTs - lastInterruptTs) < 100)
+		return;
+
 	unsigned long deltaTs = newTs - responseTimestamp;
 
 	// Wait 30us before read state to make sure digitalRead() will return the "correct" value


### PR DESCRIPTION
Fix OpenTherm reception on recent ESP32/ESPHome versions.

Ignore spurious GPIO edges shorter than 100 us observed on the
OpenTherm RX lines. These glitches caused false start-bit detection
and invalid frames (0x00000000) while valid OpenTherm traffic was
present on the bus.